### PR TITLE
orcid link added

### DIFF
--- a/_members/ufuk-tanriverdi.md
+++ b/_members/ufuk-tanriverdi.md
@@ -8,6 +8,7 @@ aliases:
   - U. Tanrıverdi
 links:
   email: ufuktanriverdi1@gmail.com
+  orcid: 0009-0000-9527-110X
   github: UfukTanriverdi8
   linkedin: ufuk-tanrıverdi-91a503264
 ---
@@ -16,5 +17,5 @@ Currently 3rd year Computer Engineering student at Hacettepe University.
 I have a **special interest in LLMs** and what they can achieve. 
 
 
-Working on generating artificial protein sequences that can mimic the function of the DNMT family. Trying to do that by utilizing an architecture
+Working on generating artificial protein sequences that can mimic the function of the DNMT family in this lab. Trying to do that by utilizing an architecture
 that integrates Transformers into a GAN setup.


### PR DESCRIPTION
Added ORCID ID and clarified lab context in the bio.

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
